### PR TITLE
Template Improvement: Better VSCode support

### DIFF
--- a/Plugin/HotLoader.csproj
+++ b/Plugin/HotLoader.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <EmbeddedResource Include="..\Template\*.*" LogicalName="Template/%(FileName)%(Extension)" />
+    <EmbeddedResource Include="..\Template\**\*" LogicalName="Template/%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/Template/.vscode/launch.json
+++ b/Template/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Attach to Rhino",
+        "type": "clr",
+        "request": "attach",
+        "processName": "Rhino.exe"
+      },
+      {
+        "name": "Attach manually",
+        "type": "clr",
+        "request": "attach",
+        "processId": "${command:pickProcess}"
+      }
+    ]
+  }

--- a/Template/.vscode/tasks.json
+++ b/Template/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "rebuild",
+        "type": "process",
+        "command": "dotnet",
+        "args": ["build", "${workspaceFolder}"],
+        "problemMatcher": "$msCompile",
+        "group": { "kind": "build", "isDefault": true }
+      }
+    ]
+}

--- a/Template/CustomComponent.csproj
+++ b/Template/CustomComponent.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -8,12 +8,10 @@
 	<TargetExt>.ghc</TargetExt>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)'=='Develop'">
-    <DebugType>full</DebugType>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Develop'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Modify default template for better VSCode experience

It's possible to have a very nice experience for developing and debugging Hot Components with VSCode.
With some modification to the default template project, the rebuilding and debugging works just as smooth as in VS
(maybe even better, since it is possible to rebuild without having to exit debug mode).

## .csproj

Project needs to generate the right style of PDB debug symbols. `DebugType=full` produces Windows PDB style, which the crossplatform VSCode debugger cannot read. Instead, use the `portable` or `embedded` style.

This doesn't break compability with VS debugger.

```
  <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Develop'">
    <DebugType>portable</DebugType>
    <DebugSymbols>true</DebugSymbols>
    <Optimize>false</Optimize>
  </PropertyGroup>
```

## Debug profile in launch.json
For better debugging experience, `launch.json` can be added to `./.vscode` folder to define custom launch configuration. This adds a debug configuration that automatically attaches the debugger to running Rhino.exe instance.

```
{
    "version": "0.2.0",
    "configurations": [
      {
        "name": "Attach to Rhino",
        "type": "clr",
        "request": "attach",
        "processName": "Rhino.exe"
      }
    ]
  }
```

If you have multiple Rhino instances running, you might have to choose the Rhino instance manually. The alternative debug configuration below prompts user to do so.

```
{
    "name": "Attach manually",
    "type": "clr",
    "request": "attach",
    "processId": "${command:pickProcess}"
}
```

## Support rebuild (and hot reload)

It is trivial to rebuild the .ghc and have it live-update in Grasshopper even while the debugger is attached
This is achieved with running `dotnet build`.

To simplify it, a default build task can be added to `.vscode/tasks.json`.
It can then be called using **Ctrl+Shift+B**.

```
{
    "version": "2.0.0",
    "tasks": [
      {
        "label": "rebuild",
        "type": "process",
        "command": "dotnet",
        "args": ["build", "${workspaceFolder}"],
        "problemMatcher": "$msCompile",
        "group": { "kind": "build", "isDefault": true }
      }
    ]
}
```

#### Limitation

After rebuild, VS code might not reattach the breakpoints correctly. One way to fix that is to disable and renable all breakpoints after each rebuild. It's currently not possbile to automate this using the project level configuration JSONs, but it can probably be achieved with some extensions.